### PR TITLE
Don't freeze signal when freezing Options (#2099)

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -2521,6 +2521,5 @@ export default class Options {
 		Object.freeze(options.retry.methods);
 		Object.freeze(options.retry.statusCodes);
 		Object.freeze(options.context);
-		Object.freeze(options.signal);
 	}
 }


### PR DESCRIPTION
Freezing the abort signal in `Options` breaks its functionality. Stop doing that.